### PR TITLE
feat: implement arrays of nested objects upload functionality

### DIFF
--- a/src/features/upload-file/components/edit.tsx
+++ b/src/features/upload-file/components/edit.tsx
@@ -1,18 +1,18 @@
 import React, { FC, useState, useEffect } from 'react'
 import { EditPropertyProps, flat } from 'admin-bro'
 import { DropZone, FormGroup, Label, DropZoneItem } from '@admin-bro/design-system'
-import PropertyCustom from '../types/property-custom.type'
+import buildCustom from '../utils/build-custom'
 
 const Edit: FC<EditPropertyProps> = ({ property, record, onChange }) => {
   const { params } = record
-  const { custom } = property as unknown as { custom: PropertyCustom }
+  const custom = buildCustom(property)
 
   const path = flat.get(params, custom.filePathProperty)
   const key = flat.get(params, custom.keyProperty)
   const file = flat.get(params, custom.fileProperty)
 
   const [originalKey, setOriginalKey] = useState(key)
-  const [filesToUpload, setFilesToUpload] = useState<Array<File>>([])
+  const [filesToUpload, setFilesToUpload] = useState<Array<File>>(file || [])
 
   useEffect(() => {
     // it means means that someone hit save and new file has been uploaded

--- a/src/features/upload-file/components/file.tsx
+++ b/src/features/upload-file/components/file.tsx
@@ -5,6 +5,7 @@ import { Icon, Button, Box } from '@admin-bro/design-system'
 import { ShowPropertyProps, flat } from 'admin-bro'
 import { ImageMimeTypes, AudioMimeTypes } from '../types/mime-types.type'
 import PropertyCustom from '../types/property-custom.type'
+import buildCustom from '../utils/build-custom'
 
 type Props = ShowPropertyProps & {
   width?: number | string;
@@ -47,7 +48,7 @@ const SingleFile: FC<SingleFileProps> = (props) => {
 }
 
 const File: FC<Props> = ({ width, record, property }) => {
-  const { custom } = property as unknown as { custom: PropertyCustom }
+  const custom = buildCustom(property)
 
   const path = flat.get(record?.params, custom.filePathProperty)
 

--- a/src/features/upload-file/factories/update-record-factory.ts
+++ b/src/features/upload-file/factories/update-record-factory.ts
@@ -5,6 +5,7 @@ import {
   ActionContext,
   UploadedFile,
   After,
+  BaseRecord,
 } from 'admin-bro'
 
 import { buildRemotePath } from '../utils/build-remote-path'
@@ -17,151 +18,175 @@ export const updateRecordFactory = (
   uploadOptionsWithDefault: UploadOptionsWithDefault,
   provider: BaseProvider,
 ): After<RecordActionResponse> => {
-  const { properties, uploadPath, multiple } = uploadOptionsWithDefault
+  const { properties: origProperties, uploadPath, multiple, parentArray } = uploadOptionsWithDefault
+
+  const processProperties = async (
+    record: BaseRecord,
+    context: ActionContext,
+    properties: UploadOptionsWithDefault['properties'],
+  ) => {
+    const {
+      [properties.file]: files,
+      [properties.filesToDelete]: filesToDelete,
+    } = getNamespaceFromContext(context)
+
+    if (multiple && filesToDelete && filesToDelete.length) {
+      const filesData = (filesToDelete as Array<string>).map((index) => ({
+        key: record.get(properties.key)[index] as string,
+        bucket: record.get(properties.bucket)[index] as string | undefined,
+      }))
+
+      await Promise.all(filesData.map(async (fileData) => (
+        provider.delete(fileData.key, fileData.bucket || provider.bucket, context)
+      )))
+
+      const newParams = DB_PROPERTIES.reduce((params, propertyName: string) => {
+        if (properties[propertyName]) {
+          const filtered = record.get(properties[propertyName]).filter((el, i) => (
+            !filesToDelete.includes(i.toString())
+          ))
+          return flat.set(params, properties[propertyName], filtered)
+        }
+        return params
+      }, {})
+
+      record.storeParams(newParams)
+    }
+    if (multiple && files) {
+      const uploadedFiles = files as Array<UploadedFile>
+
+      const keys = await Promise.all<string>(uploadedFiles.map(async (uploadedFile) => {
+        const key = buildRemotePath(record, uploadedFile, uploadPath)
+        await provider.upload(uploadedFile, key, context)
+        return key
+      }))
+
+      let params = flat.set({}, properties.key, [
+        ...(record.get(properties.key) || []),
+        ...keys,
+      ])
+      if (properties.bucket) {
+        params = flat.set(params, properties.bucket, [
+          ...(record.get(properties.bucket) || []),
+          ...uploadedFiles.map(() => provider.bucket),
+        ])
+      }
+      if (properties.size) {
+        params = flat.set(params, properties.size, [
+          ...(record.get(properties.size) || []),
+          ...uploadedFiles.map((file) => file.size),
+        ])
+      }
+      if (properties.mimeType) {
+        params = flat.set(params, properties.mimeType, [
+          ...(record.get(properties.mimeType) || []),
+          ...uploadedFiles.map((file) => file.type),
+        ])
+      }
+      if (properties.filename) {
+        params = flat.set(params, properties.filename, [
+          ...(record.get(properties.filename) || []),
+          ...uploadedFiles.map((file) => file.name),
+        ])
+      }
+
+      record.storeParams(params)
+      return
+    }
+
+    if (!multiple && files && files.length) {
+      const uploadedFile: UploadedFile = files[0]
+
+      const oldRecordParams = { ...record.params }
+      const key = buildRemotePath(record, uploadedFile, uploadPath)
+
+      await provider.upload(uploadedFile, key, context)
+
+      const params = {
+        [properties.key]: key,
+        ...properties.bucket && { [properties.bucket]: provider.bucket },
+        ...properties.size && { [properties.size]: uploadedFile.size?.toString() },
+        ...properties.mimeType && { [properties.mimeType]: uploadedFile.type },
+        ...properties.filename && { [properties.filename]: uploadedFile.name as string },
+      }
+
+      record.storeParams(params)
+
+      const oldKey = oldRecordParams[properties.key] && oldRecordParams[properties.key]
+      const oldBucket = (
+        properties.bucket && oldRecordParams[properties.bucket]
+      ) || provider.bucket
+
+      if (oldKey && oldBucket && (oldKey !== key || oldBucket !== provider.bucket)) {
+        await provider.delete(oldKey, oldBucket, context)
+      }
+
+      return
+    }
+
+    // someone wants to remove one file
+    if (!multiple && files === null) {
+      const bucket = (properties.bucket && record.get(properties.bucket)) || provider.bucket
+      const key = record.get(properties.key) as string | undefined
+
+      // and file exists
+      if (key && bucket) {
+        const params = {
+          [properties.key]: null,
+          ...properties.bucket && { [properties.bucket]: null },
+          ...properties.size && { [properties.size]: null },
+          ...properties.mimeType && { [properties.mimeType]: null },
+          ...properties.filename && { [properties.filename]: null },
+        }
+
+        record.storeParams(params)
+        await provider.delete(key, bucket, context)
+      }
+    }
+  }
 
   const updateRecord = async (
     response: RecordActionResponse,
     request: ActionRequest,
     context: ActionContext,
   ): Promise<RecordActionResponse> => {
-    const { record } = context
-
-    const {
-      [properties.file]: files,
-      [properties.filesToDelete]: filesToDelete,
-    } = getNamespaceFromContext(context)
-
     const { method } = request
+    const { record } = context
 
     if (method !== 'post') {
       return response
     }
 
     if (record && record.isValid()) {
-      if (multiple && filesToDelete && filesToDelete.length) {
-        const filesData = (filesToDelete as Array<string>).map((index) => ({
-          key: record.get(properties.key)[index] as string,
-          bucket: record.get(properties.bucket)[index] as string | undefined,
-        }))
+      const data = getNamespaceFromContext(context)
 
-        await Promise.all(filesData.map(async (fileData) => (
-          provider.delete(fileData.key, fileData.bucket || provider.bucket, context)
-        )))
-
-        const newParams = DB_PROPERTIES.reduce((params, propertyName: string) => {
-          if (properties[propertyName]) {
-            const filtered = record.get(properties[propertyName]).filter((el, i) => (
-              !filesToDelete.includes(i.toString())
-            ))
-            return flat.set(params, properties[propertyName], filtered)
-          }
-          return params
-        }, {})
-
-        await record.update(newParams)
-      }
-      if (multiple && files) {
-        const uploadedFiles = files as Array<UploadedFile>
-
-        const keys = await Promise.all<string>(uploadedFiles.map(async (uploadedFile) => {
-          const key = buildRemotePath(record, uploadedFile, uploadPath)
-          await provider.upload(uploadedFile, key, context)
-          return key
-        }))
-
-        let params = flat.set({}, properties.key, [
-          ...(record.get(properties.key) || []),
-          ...keys,
-        ])
-        if (properties.bucket) {
-          params = flat.set(params, properties.bucket, [
-            ...(record.get(properties.bucket) || []),
-            ...uploadedFiles.map(() => provider.bucket),
-          ])
-        }
-        if (properties.size) {
-          params = flat.set(params, properties.size, [
-            ...(record.get(properties.size) || []),
-            ...uploadedFiles.map((file) => file.size),
-          ])
-        }
-        if (properties.mimeType) {
-          params = flat.set(params, properties.mimeType, [
-            ...(record.get(properties.mimeType) || []),
-            ...uploadedFiles.map((file) => file.type),
-          ])
-        }
-        if (properties.filename) {
-          params = flat.set(params, properties.filename, [
-            ...(record.get(properties.filename) || []),
-            ...uploadedFiles.map((file) => file.name),
-          ])
-        }
-
-        await record.update(params)
-
-        return {
-          ...response,
-          record: record.toJSON(context.currentAdmin),
+      if (parentArray) {
+        const items: Record<string, any>[] = flat.get(data, parentArray)
+        if (items) {
+          // Call processProperties with the properties mapped for each aray item.
+          await Promise.all(items.map(async (_item, index) => {
+            const basePath = [parentArray, index].join(flat.DELIMITER)
+            const mappedProperties = Object.keys(origProperties).reduce((memo, prop) => ({
+              ...memo,
+              [prop]: [basePath, origProperties[prop]].join(flat.DELIMITER),
+            }), { ...origProperties })
+            return processProperties(
+              record,
+              context,
+              mappedProperties,
+            )
+          }))
         }
       }
 
-      if (!multiple && files && files.length) {
-        const uploadedFile: UploadedFile = files[0]
+      await processProperties(record, context, origProperties)
 
-        const oldRecordParams = { ...record.params }
-        const key = buildRemotePath(record, uploadedFile, uploadPath)
+      // Save any updates made by record.storeParams
+      await record.save()
 
-        await provider.upload(uploadedFile, key, context)
-
-        const params = {
-          [properties.key]: key,
-          ...properties.bucket && { [properties.bucket]: provider.bucket },
-          ...properties.size && { [properties.size]: uploadedFile.size?.toString() },
-          ...properties.mimeType && { [properties.mimeType]: uploadedFile.type },
-          ...properties.filename && { [properties.filename]: uploadedFile.name as string },
-        }
-
-        await record.update(params)
-
-        const oldKey = oldRecordParams[properties.key] && oldRecordParams[properties.key]
-        const oldBucket = (
-          properties.bucket && oldRecordParams[properties.bucket]
-        ) || provider.bucket
-
-        if (oldKey && oldBucket && (oldKey !== key || oldBucket !== provider.bucket)) {
-          await provider.delete(oldKey, oldBucket, context)
-        }
-
-        return {
-          ...response,
-          record: record.toJSON(context.currentAdmin),
-        }
-      }
-
-      // someone wants to remove one file
-      if (!multiple && files === null) {
-        const bucket = (properties.bucket && record.get(properties.bucket)) || provider.bucket
-        const key = record.get(properties.key) as string | undefined
-
-        // and file exists
-        if (key && bucket) {
-          const params = {
-            [properties.key]: null,
-            ...properties.bucket && { [properties.bucket]: null },
-            ...properties.size && { [properties.size]: null },
-            ...properties.mimeType && { [properties.mimeType]: null },
-            ...properties.filename && { [properties.filename]: null },
-          }
-
-          await record.update(params)
-          await provider.delete(key, bucket, context)
-
-          return {
-            ...response,
-            record: record.toJSON(context.currentAdmin),
-          }
-        }
+      return {
+        ...response,
+        record: record.toJSON(context.currentAdmin),
       }
     }
 

--- a/src/features/upload-file/types/property-custom.type.ts
+++ b/src/features/upload-file/types/property-custom.type.ts
@@ -17,6 +17,7 @@ type PropertyCustom = {
   maxSize?: number,
   provider: string,
   multiple: boolean,
+  parentArray?: string,
 }
 
 export default PropertyCustom

--- a/src/features/upload-file/types/upload-options.type.ts
+++ b/src/features/upload-file/types/upload-options.type.ts
@@ -73,6 +73,11 @@ export type UploadOptions = {
    */
   multiple?: boolean,
 
+  /**
+   * Array property that the properties are nested within.
+   */
+  parentArray?: string,
+
   /** Validation rules */
   validation?: {
     /**
@@ -96,6 +101,7 @@ export type UploadOptionsWithDefault = {
 
 export type FeatureInvocation = {
   properties: Partial<UploadOptions['properties']>
+  parentArray?: string
 }
 
 /**

--- a/src/features/upload-file/upload-file.feature.ts
+++ b/src/features/upload-file/upload-file.feature.ts
@@ -24,7 +24,7 @@ const DEFAULT_FILE_PATH_PROPERTY = 'filePath'
 const DEFAULT_FILES_TO_DELETE_PROPERTY = 'filesToDelete'
 
 const uploadFileFeature = (config: UploadOptions): FeatureType => {
-  const { provider: providerOptions, validation, multiple } = config
+  const { provider: providerOptions, validation, multiple, parentArray } = config
 
   const configWithDefault: UploadOptionsWithDefault = {
     ...config,
@@ -81,11 +81,13 @@ const uploadFileFeature = (config: UploadOptions): FeatureType => {
     mimeTypes: validation?.mimeTypes,
     maxSize: validation?.maxSize,
     multiple: !!multiple,
+    parentArray,
   }
+  const fileProperty = parentArray ? `${parentArray}.${properties.file}` : properties.file
 
   const uploadFeature = buildFeature({
     properties: {
-      [properties.file]: {
+      [fileProperty]: {
         custom,
         isVisible: { show: true, edit: true, list: true, filter: false },
         components: {

--- a/src/features/upload-file/utils/build-custom.ts
+++ b/src/features/upload-file/utils/build-custom.ts
@@ -1,0 +1,37 @@
+import { flat, PropertyJSON } from 'admin-bro'
+import PropertyCustom from '../types/property-custom.type'
+
+export default (property: PropertyJSON): PropertyCustom => {
+  const { custom } = property as unknown as { custom: PropertyCustom }
+
+  if (custom.parentArray) {
+    // Array OR mixed property
+    // TODO look at adding mixed property support
+    // TODO Handle the case were `parentArray` is nested within another array.
+    const parts = flat.pathToParts(property.path)
+    const parentArrayIndex = parts.indexOf(custom.parentArray)
+    if (parentArrayIndex === -1) {
+      return custom
+    }
+    const parentPath = parts[parentArrayIndex + 1]
+    const updates = [
+      'fileProperty',
+      'filePathProperty',
+      'filesToDeleteProperty',
+      'keyProperty',
+    ].reduce((memo, prop) => {
+      const val = custom[prop]
+      return {
+        ...memo,
+        [prop]: val && [parentPath, val].join(flat.DELIMITER),
+      }
+    }, {})
+
+    return {
+      ...custom,
+      ...updates,
+    }
+  }
+
+  return custom
+}

--- a/src/features/upload-file/utils/fill-record-with-path.ts
+++ b/src/features/upload-file/utils/fill-record-with-path.ts
@@ -8,26 +8,49 @@ export const fillRecordWithPath = async (
   uploadOptionsWithDefault: UploadOptionsWithDefault,
   provider: BaseProvider,
 ): Promise<RecordJSON> => {
-  const { properties, multiple } = uploadOptionsWithDefault
+  const { properties, multiple, parentArray } = uploadOptionsWithDefault
 
-  const key = flat.get(record?.params, properties.key)
-  const storedBucket = properties.bucket && flat.get(record?.params, properties.bucket)
+  const getPath = async (
+    keyProperty: string,
+    bucketProperty?: string,
+  ): Promise<string | string[] | undefined> => {
+    const key = flat.get(record?.params, keyProperty)
+    const storedBucket = bucketProperty && flat.get(record?.params, bucketProperty)
 
-  let filePath: string | Array<string> | undefined
-  if (multiple && key && key.length) {
-    filePath = await Promise.all(key.map(async (singleKey, index) => (
-      provider.path(
-        singleKey, storedBucket?.[index] ?? provider.bucket, context,
+    if (multiple && key && key.length) {
+      return Promise.all(key.map(async (singleKey, index) => (
+        provider.path(
+          singleKey, storedBucket?.[index] ?? provider.bucket, context,
+        )
+      )))
+    }
+
+    if (!multiple && key) {
+      return provider.path(
+        key, storedBucket ?? provider.bucket, context,
       )
-    )))
-  } else if (!multiple && key) {
-    filePath = await provider.path(
-      key, storedBucket ?? provider.bucket, context,
-    )
+    }
+
+    return undefined
   }
 
-  return {
-    ...record,
-    params: flat.set(record.params, properties.filePath, filePath),
+  const { key, bucket, filePath } = properties
+  let { params } = record
+
+  if (parentArray) {
+    const items: Record<string, any>[] = flat.get(params, parentArray)
+    if (items) {
+      await Promise.all(items.map(async (_item, index) => {
+        const path = await getPath(
+          [parentArray, index, key].join(flat.DELIMITER),
+          bucket && [parentArray, index, bucket].join(flat.DELIMITER),
+        )
+        params = flat.set(params, [parentArray, index, filePath].join(flat.DELIMITER), path)
+      }))
+    }
+  } else {
+    params = flat.set(params, filePath, await getPath(key, bucket))
   }
+
+  return { ...record, params }
 }

--- a/src/features/upload-file/utils/validate-properties.ts
+++ b/src/features/upload-file/utils/validate-properties.ts
@@ -5,6 +5,10 @@ const invocationPrefix = (index) => (
   `__invocation__${index}__`
 )
 
+const propertyPrefix = (invocation: FeatureInvocation) => (
+  invocation.parentArray ? `${invocation.parentArray}.` : ''
+)
+
 /**
  * Checks if values for properties given by the user are different
  *
@@ -51,7 +55,7 @@ export const validatePropertiesGlobally = (
       ...Object.keys(invocation.properties).reduce((props, key) => (
         {
           ...props,
-          [`${invocationPrefix(index)}${key}`]: invocation.properties[key],
+          [`${invocationPrefix(index)}${key}`]: `${propertyPrefix(invocation)}${invocation.properties[key]}`,
         }
       ), {}),
     }),


### PR DESCRIPTION
This PR adds the ability to upload an array of nested objects that can each have an  (upload) file. 

The use case is where you want to store a number of nested objects that can each have (upload) files. For example an array of photos on a (blog) post:

```
const photoSchema = new Schema({
  name: 'string',
  bucket: 'string',
  mime: 'string',
  key: 'string',
  size: 'number'
});
const postSchema = new Schema({
  name: 'string', 
  photos: [photoSchema],
});
```

To achieve this I have added a new option (`parentArray`) to the `uploadFeature` options. The `parentArray` option indicates that the (upload) feature should be nested under a parent array property.

For the above `post` example (with `photos`) the `uploadFeature` options would be something like:

```
  features: [uploadFeature({
    properties: { file: 'file', key: 'key', bucket: 'bucket', mimeType: 'mime', size: 'size' },
    parentArray: 'photos'
  })],
```

The code handles the `parentArray` case by building the properties "on the fly", to match the items array of photos. So `file` gets mapped to `photos.0.file`, `photos.1.file`, etc.,

I was hoping this would be achievable with fewer changes, but unfortunately it resulted in a fairly significant rewrite in particular of `updateRecordFactory`, which it now handles multiple uploads in a single call to `updateRecord`.

If you are interested in including this feature then I can add an example and tests for the new cases along with any improvements / alterations that you require, but I first wanted to get an indication of whether you see this as a worthwhile addition.

If not I could publish it as an `upload-array-file` feature.

Please let me know if you have some contribution or similar guidelines that I have missed.

Thanks for your time and for providing a great library! 
