### PR TITLE
Update local-provider.ts

### DIFF
--- a/src/features/upload-file/providers/local-provider.ts
+++ b/src/features/upload-file/providers/local-provider.ts
@@ -18,7 +18,7 @@ export type LocalUploadOptions = {
   /**
    * options for local provider
    */
-  opts: ProviderOpts;
+  opts?: ProviderOpts;
 };
 
 export class LocalProvider extends BaseProvider {


### PR DESCRIPTION
Make opts in LocalUploadOptions optional, because it contains only one property (baseUrl) which is optional.