### PR TITLE
feat: pass file to upload path function

### DIFF
--- a/src/features/upload-file/factories/update-record-factory.ts
+++ b/src/features/upload-file/factories/update-record-factory.ts
@@ -63,7 +63,7 @@ export const updateRecordFactory = (
         const uploadedFiles = files as Array<UploadedFile>
 
         const keys = await Promise.all<string>(uploadedFiles.map(async (uploadedFile) => {
-          const key = buildRemotePath(record, uploadedFile, uploadPath)
+          const key = await buildRemotePath(record, uploadedFile, uploadPath)
           await provider.upload(uploadedFile, key, context)
           return key
         }))
@@ -109,7 +109,7 @@ export const updateRecordFactory = (
         const uploadedFile: UploadedFile = files[0]
 
         const oldRecordParams = { ...record.params }
-        const key = buildRemotePath(record, uploadedFile, uploadPath)
+        const key = await buildRemotePath(record, uploadedFile, uploadPath)
 
         await provider.upload(uploadedFile, key, context)
 

--- a/src/features/upload-file/types/upload-options.type.ts
+++ b/src/features/upload-file/types/upload-options.type.ts
@@ -1,4 +1,4 @@
-import { BaseRecord, ComponentLoader } from 'adminjs'
+import { BaseRecord, ComponentLoader, UploadedFile } from 'adminjs'
 import { AWSOptions } from '../providers/aws-provider.js'
 import { BaseProvider } from '../providers/base-provider.js'
 import { GCPOptions } from '../providers/gcp-provider.js'
@@ -24,7 +24,11 @@ export type UploadPathFunction = (
    * filename with extension
    */
   filename: string,
-) => string
+  /**
+   * File to upload
+   */
+  file: UploadedFile,
+) => string | Promise<string>
 
 /**
  * Configuration options for @adminjs/upload feature

--- a/src/features/upload-file/utils/build-remote-path.spec.ts
+++ b/src/features/upload-file/utils/build-remote-path.spec.ts
@@ -26,17 +26,17 @@ describe('buildPath', () => {
     recordStub.params = {}
   })
 
-  it('returns default path when no custom function is given', () => {
-    expect(buildRemotePath(recordStub, File)).to.equal(`${recordId}/${File.name}`)
+  it('returns default path when no custom function is given', async () => {
+    expect(await buildRemotePath(recordStub, File)).to.equal(`${recordId}/${File.name}`)
   })
 
-  it('returns default custom path when function is given', () => {
+  it('returns custom path when function is given', async () => {
     const newPath = '1/1/filename'
-    const fnStub = sinon.stub<[BaseRecord, string], string>().returns(newPath)
+    const fnStub = sinon.stub<[BaseRecord, string, UploadedFile], string>().returns(newPath)
 
-    const path = buildRemotePath(recordStub, File, fnStub)
+    const path = await buildRemotePath(recordStub, File, fnStub)
 
     expect(path).to.equal(newPath)
-    expect(fnStub).to.have.been.calledWith(recordStub, File.name)
+    expect(fnStub).to.have.been.calledWith(recordStub, File.name, File)
   })
 })

--- a/src/features/upload-file/utils/build-remote-path.ts
+++ b/src/features/upload-file/utils/build-remote-path.ts
@@ -18,7 +18,7 @@ export const buildRemotePath = (
   record: BaseRecord,
   file: UploadedFile,
   uploadPathFunction?: UploadPathFunction,
-): string => {
+): string | Promise<string> => {
   if (!record.id()) {
     throw new Error(ERROR_MESSAGES.NO_PERSISTENT_RECORD_UPLOAD)
   }
@@ -28,7 +28,7 @@ export const buildRemotePath = (
   const { ext, name } = path.parse(file.name)
 
   if (uploadPathFunction) {
-    return uploadPathFunction(record, `${name}${ext}`)
+    return uploadPathFunction(record, `${name}${ext}`, file)
   }
 
   return `${record.id()}/${name}${ext}`


### PR DESCRIPTION
This allows generating a key based on the contents of the file, such as the hash of the file, or other metadata.