### PR TITLE
feat: add feedback to edit component form

### DIFF
--- a/src/features/upload-file/components/UploadEditComponent.tsx
+++ b/src/features/upload-file/components/UploadEditComponent.tsx
@@ -1,12 +1,13 @@
-import { DropZone, DropZoneItem, FormGroup, Label } from '@adminjs/design-system'
+import { DropZone, DropZoneItem, FormGroup, FormMessage, Label } from '@adminjs/design-system'
 import { EditPropertyProps, flat, useTranslation } from 'adminjs'
 import React, { FC, useEffect, useState } from 'react'
 import PropertyCustom from '../types/property-custom.type.js'
 
 const Edit: FC<EditPropertyProps> = ({ property, record, onChange }) => {
-  const { translateProperty } = useTranslation()
+  const { translateProperty, tm } = useTranslation()
   const { params } = record
   const { custom } = property as unknown as { custom: PropertyCustom }
+  const error = record.errors?.[property.path]
 
   const path = flat.get(params, custom.filePathProperty)
   const key = flat.get(params, custom.keyProperty)
@@ -63,7 +64,7 @@ const Edit: FC<EditPropertyProps> = ({ property, record, onChange }) => {
   }
 
   return (
-    <FormGroup>
+    <FormGroup error={Boolean(error)}>
       <Label>{translateProperty(property.label, property.resourceId)}</Label>
       <DropZone
         onChange={onUpload}
@@ -96,6 +97,7 @@ const Edit: FC<EditPropertyProps> = ({ property, record, onChange }) => {
           })}
         </>
       ) : ''}
+      <FormMessage>{error && tm(error.message, property.resourceId)}</FormMessage>
     </FormGroup>
   )
 }


### PR DESCRIPTION
This adds the ability to add validation messages to the file field using custom actions, implemented in the same way as the default adminjs edit component https://github.com/SoftwareBrothers/adminjs/blob/262fa77163747f6dd340fbeffcbf46386801edf1/src/frontend/components/property-type/default-type/edit.tsx#L13-L25